### PR TITLE
Fix wrong image path

### DIFF
--- a/toolbar.php
+++ b/toolbar.php
@@ -1,7 +1,7 @@
 <?php
 global $link;
 
-echo stylesheet_tag("plugins.local/framarticle_toolbar/css/font-awesome.css");
+echo stylesheet_tag("plugins/framarticle_toolbar/css/font-awesome.css");
 print_user_stylesheet($link);
 ?>
 <span id="framarticle-toolbar">


### PR DESCRIPTION
As the plugin is installed in `plugins/` the path `plugins.local/` results in a 404 error